### PR TITLE
Potential fix for code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/skodachargefrontend/skodachargefrontend.py
+++ b/skodachargefrontend/skodachargefrontend.py
@@ -7,6 +7,7 @@ import time
 from zoneinfo import ZoneInfo
 
 from fastapi import BackgroundTasks, FastAPI, Query, Request
+import html
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from helpers import (
     compute_daily_totals_home,
@@ -354,11 +355,11 @@ async def root(
                     </div>
                 </div>
                 <div class="text-center mt-8">
-                    <a href="/?year={prev_year}&month={prev_month}" class="text-blue-400 hover:underline">&laquo; Previous Month</a>
+                    <a href="/?year={html.escape(str(prev_year))}&month={html.escape(str(prev_month))}" class="text-blue-400 hover:underline">&laquo; Previous Month</a>
                     <span class="mx-2 text-white">|</span>
                     <a href="/" class="text-blue-400 hover:underline">Home</a>
                     <span class="mx-2 text-white">|</span>
-                    <a href="/?year={next_year}&month={next_month}" class="text-blue-400 hover:underline">Next Month &raquo;</a>
+                    <a href="/?year={html.escape(str(next_year))}&month={html.escape(str(next_month))}" class="text-blue-400 hover:underline">Next Month &raquo;</a>
                 </div>
                 <div class="text-center mt-4 text-gray-400 text-sm">
                     Build:


### PR DESCRIPTION
Potential fix for [https://github.com/tn8or/skoda/security/code-scanning/5](https://github.com/tn8or/skoda/security/code-scanning/5)

To fix the reflected server-side XSS vulnerability, **all user-controlled values interpolated into HTML content must be safely escaped** for use in HTML contexts, even if their types are restricted. In this case, escape the navigation-link parameters (`year`, `prev_year`, `next_year`, `month`, `prev_month`, `next_month`) as they're interpolated directly in HTML links. Use the standard library's `html.escape()` function for this purpose. As all relevant values are Python integers, converting them to strings before escaping is sufficient. The fix requires:

- Importing `html` from the standard library.
- Escaping every interpolated instance of these variables in the returned HTML (i.e., all usages in the anchor `href` attributes).
- The fix is strictly limited to the shown file (`skodachargefrontend/skodachargefrontend.py`). No changes outside of this file, nor deep refactoring, are permissible.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
