### PR TITLE
Potential fix for code scanning alert no. 9: Reflected server-side cross-site scripting

### DIFF
--- a/skodachargefrontend/skodachargefrontend.py
+++ b/skodachargefrontend/skodachargefrontend.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from zoneinfo import ZoneInfo
-
+import html
 from fastapi import BackgroundTasks, FastAPI, Query, Request
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from helpers import (
@@ -132,7 +132,7 @@ async def root(
         <!DOCTYPE html>
         <html>
         <head>
-            <title>Charge Summary for {year}-{month:02d}</title>
+            <title>Charge Summary for {html.escape(str(year))}-{html.escape(f"{month:02d}")}</title>
             <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
         </head>
         <body class="bg-black">
@@ -140,16 +140,16 @@ async def root(
                 <div class="container px-5 py-12 mx-auto lg:px-20">
                     <div class="flex flex-col flex-wrap pb-6 mb-12 text-white">
                         <h1 class="mb-12 text-3xl font-medium text-white">
-                            Charge Summary for {year}-{month:02d}
+                            Charge Summary for {html.escape(str(year))}-{html.escape(f"{month:02d}")} 
                         </h1>
                         <p class="text-white text-xl">No charge data found for this month.</p>
                     </div>
                     <div class="text-center mt-8">
-                        <a href="/?year={prev_year}&month={prev_month}" class="text-blue-400 hover:underline">&laquo; Previous Month</a>
+                        <a href="/?year={html.escape(str(prev_year))}&month={html.escape(str(prev_month))}" class="text-blue-400 hover:underline">&laquo; Previous Month</a>
                         <span class="mx-2 text-white">|</span>
                         <a href="/" class="text-blue-400 hover:underline">Home</a>
                         <span class="mx-2 text-white">|</span>
-                        <a href="/?year={next_year}&month={next_month}" class="text-blue-400 hover:underline">Next Month &raquo;</a>
+                        <a href="/?year={html.escape(str(next_year))}&month={html.escape(str(next_month))}" class="text-blue-400 hover:underline">Next Month &raquo;</a>
                     </div>
                     <div class="text-center mt-8 text-gray-400 text-sm">
                         Build:


### PR DESCRIPTION
Potential fix for [https://github.com/tn8or/skoda/security/code-scanning/9](https://github.com/tn8or/skoda/security/code-scanning/9)

The best way to fix the problem is to defensively escape all variables injected into HTML that originate from user input, even if they're currently constrained in type. In this case, all usage of `year` and `month` in the HTML output should be safely escaped. Since they're integers (and not strings), escaping is technically not strictly needed, but using `html.escape(str(...))` ensures future-proof safety, especially if other query params are added, or types loosened. In this file (`skodachargefrontend/skodachargefrontend.py`), you should import the standard `html` module, and wrap each usage of `{year}` and `{month}` in the HTML blocks with `html.escape(str(year))` and `html.escape(str(month))` (similarly for any other query-param-derived values appearing in HTML). Since some usages are in attributes (`href=...`) and inner text, escaping is always safe. If you want to aggressively avoid unnecessary escaping for integers, you can just typecast and keep, but best practice is to consistently escape user-controlled values in HTML contexts. Add an import for `html` at the top if missing.

Edits to make:
- Add `import html` at top if missing.
- Replace all `{year}` and `{month:02d}` in the HTML response for the no-sessions branch (lines 131-164) with `{html.escape(str(year))}` and `{html.escape(f"{month:02d}")}`.
- Similarly, for prev_year, prev_month, next_year, next_month in `href`, escape them as well.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
