### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tn8or/skoda/security/code-scanning/10](https://github.com/tn8or/skoda/security/code-scanning/10)

To fix this issue, we should add a `permissions` block to the workflow. The best place to add it is at the top-level, beneath the workflow name, so that it applies to all jobs unless overridden. Since this CI workflow only needs to check out source code and does not perform any write operations (like updating issues, pull requests, or uploading releases), the minimal required permission is `contents: read`.  
The change involves editing `.github/workflows/ci.yml`, inserting the following lines directly after the `name: CI` line:

```yaml
permissions:
  contents: read
```

No changes are needed in any other steps, and no additional dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
