### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ghcr-image.yml
+++ b/.github/workflows/ghcr-image.yml
@@ -90,6 +90,7 @@ jobs:
   notify-webhook:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
+    permissions: {}
     needs: build-and-push-image
     steps:
       - name: Invoke deployment hook


### PR DESCRIPTION
Potential fix for [https://github.com/tn8or/skoda/security/code-scanning/11](https://github.com/tn8or/skoda/security/code-scanning/11)

To resolve this issue, explicitly set the minimum required permissions for the "notify-webhook" job. The job's only step is to send an external webhook; it does not interact with repository contents, packages, issues, or other privileged resources. According to GitHub documentation, most notification jobs like this can use:  
```yaml
permissions: {}  
```  
which disables GITHUB_TOKEN altogether, or  
```yaml
permissions:
  contents: read
```  
if the job depends on GITHUB_TOKEN for some API calls. The best fix is to add `permissions: {}` as the first key under "notify-webhook" (after `runs-on` and `if`, but before `needs` unless jobs ordering or syntax requires otherwise; usually under `runs-on`). Ensure proper indentation, matching the style of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
