### PR TITLE
Remove pip upgrade step from CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,7 +64,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install pip-audit
-        run: pip install pip-audit
+        run: python -m pip install --upgrade pip pip-audit
 
       - name: Run pip-audit
         working-directory: ${{ matrix.service }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,10 +63,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Upgrade pip securely via proxy
-        run: |
-          python -m pip install --upgrade pip
-
       - name: Install pip-audit
         run: pip install pip-audit
 


### PR DESCRIPTION
Removed the step to upgrade pip securely via proxy.